### PR TITLE
Remove debug buttons and improve data refresh behavior

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -263,8 +263,8 @@ export default function Index() {
       fetchGoogleSheetData();
     };
 
-    window.addEventListener('focus', handleFocus);
-    return () => window.removeEventListener('focus', handleFocus);
+    window.addEventListener("focus", handleFocus);
+    return () => window.removeEventListener("focus", handleFocus);
   }, []);
 
   // Fetch data when page becomes visible again
@@ -275,8 +275,9 @@ export default function Index() {
       }
     };
 
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
   }, []);
 
   // Function to convert Google Drive links to direct image URLs


### PR DESCRIPTION
## Purpose

The user requested to remove the debug buttons (refresh sheet data, show sheet data, and show all conversations) and improve the data fetching behavior to automatically refresh data whenever a person refreshes the page or returns to the tab.

## Code changes

- **Removed debug section**: Eliminated the debug buttons including "Refresh Sheet Data", "Show Raw CSV", and "Show All Conversations" from the UI
- **Improved auto-refresh logic**: 
  - Replaced 5-minute interval-based refresh with event-driven refresh
  - Added focus event listener to fetch data when user returns to the tab
  - Added visibility change event listener to fetch data when page becomes visible again
  - Maintained initial data fetch on component mount
- **Simplified UI**: Kept only the conversation count display in a cleaner status section

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/999d3dea168b42f695ece164cae528fc/neon-space)

👀 [Preview Link](https://999d3dea168b42f695ece164cae528fc-neon-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>999d3dea168b42f695ece164cae528fc</projectId>-->
<!--<branchName>neon-space</branchName>-->